### PR TITLE
Refactor avatar storage to use keys and dynamic URLs

### DIFF
--- a/src/components/AvatarUpload.jsx
+++ b/src/components/AvatarUpload.jsx
@@ -3,8 +3,8 @@ import SecureFileUpload from './SecureFileUpload';
 
 const AvatarUpload = ({ currentAvatar, onAvatarUpdate }) => {
   const handleAvatarUpdate = (fileUrl, fileKey) => {
-    // 传递文件URL给父组件
-    onAvatarUpdate(fileUrl);
+    // 传递文件key给父组件
+    onAvatarUpdate(fileKey);
   };
 
   return (

--- a/src/components/MyPage.jsx
+++ b/src/components/MyPage.jsx
@@ -46,7 +46,7 @@ const MyPage = () => {
       nickname: cognitoUserInfo?.nickname,
       name: cognitoUserInfo?.name || authContextUser.attributes?.name,
       preferred_username: authContextUser.attributes?.preferred_username,
-      picture: authContextUser.attributes?.picture
+      avatarKey: cognitoUserInfo?.avatarKey || authContextUser.attributes?.avatarKey
     },
     username: authContextUser.username
   } : {

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -1,3 +1,5 @@
+import { getAvatarUrl } from '../api.js';
+
 /**
  * 头像生成和处理工具函数
  */
@@ -50,13 +52,16 @@ export const generateAvatar = (name, size = 40) => {
  * @param {number} size - 头像尺寸，默认40
  * @returns {string} 头像URL
  */
-export const getUserAvatarUrl = (user, size = 40) => {
-  // 优先使用用户上传的头像
-  if (user?.attributes?.picture && user.attributes.picture !== '') {
-    return user.attributes.picture;
+export const getUserAvatarUrl = async (user, size = 40) => {
+  if (user?.attributes?.avatarKey) {
+    try {
+      const url = await getAvatarUrl(user?.userId || user?.attributes?.sub);
+      if (url) return url;
+    } catch (error) {
+      console.error('获取头像URL失败:', error);
+    }
   }
 
-  // 获取用户名，优先使用Cognito的nickname，然后是name，最后是email的用户名部分
   const userName = user?.attributes?.nickname ||
     user?.attributes?.name ||
     user?.attributes?.preferred_username ||


### PR DESCRIPTION
## Summary
- store Cognito avatar key instead of presigned URL and refresh Cognito info accordingly
- fetch avatar URL on demand via new async `getUserAvatarUrl`
- propagate avatar key through profile and auth components and refresh uploaded avatars

## Testing
- `npx eslint src/utils/avatar.js src/components/AvatarUpload.jsx src/components/UserProfileManager.jsx src/components/Auth.jsx src/contexts/AuthContext.jsx src/components/MyPage.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68bdc991473c8324bb7bfa9546869937