### PR TITLE
Introduce app error hierarchy and clean API usage

### DIFF
--- a/src/components/ApiErrorNotice.jsx
+++ b/src/components/ApiErrorNotice.jsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useId, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { formatApiError } from '../utils/formatApiError.js';
+
+const baseClasses = 'rounded-md border border-red-200 bg-red-50 text-red-700';
+
+export function ApiErrorNotice({
+  error,
+  onRetry,
+  retryLabel = '重试',
+  className = '',
+  compact = false,
+  includeResponseBody = false
+}) {
+  if (!error) return null;
+  const formatted = useMemo(() => formatApiError(error, { includeResponseBody }), [error, includeResponseBody]);
+  const { summary, detailItems } = formatted;
+  const [expanded, setExpanded] = useState(false);
+  const detailId = useId();
+
+  useEffect(() => {
+    setExpanded(false);
+  }, [error]);
+
+  const containerClasses = [
+    baseClasses,
+    compact ? 'px-3 py-2 text-xs' : 'px-4 py-3 text-sm',
+    'shadow-sm',
+    'space-y-1',
+    className
+  ].filter(Boolean).join(' ');
+
+  const retryButtonClasses = compact
+    ? 'mt-1 inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-red-600 text-white hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1'
+    : 'mt-2 inline-flex items-center rounded px-3 py-1.5 text-xs font-medium bg-red-600 text-white hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1';
+
+  const buttonClasses = compact
+    ? 'inline-flex items-center rounded px-2 py-1 text-[11px] font-medium text-red-700 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-1'
+    : 'inline-flex items-center rounded px-2.5 py-1.5 text-xs font-medium text-red-700 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-1';
+
+  return (
+    <div role="alert" aria-live="polite" className={containerClasses}>
+      <div className={compact ? 'font-semibold' : 'text-sm font-semibold'}>{summary}</div>
+      {detailItems.length > 0 && (
+        <div className="flex flex-wrap items-start gap-2">
+          <button
+            type="button"
+            className={buttonClasses}
+            aria-expanded={expanded}
+            aria-controls={detailId}
+            onClick={() => setExpanded(prev => !prev)}
+          >
+            {expanded ? '收起详情' : '显示全部'}
+          </button>
+        </div>
+      )}
+      {expanded && detailItems.length > 0 && (
+        <ul id={detailId} className={compact ? 'mt-1 space-y-0.5 text-[11px]' : 'mt-2 space-y-0.5 text-xs'}>
+          {detailItems.map(({ label, value }, index) => (
+            <li key={`${label}-${index}`} className="flex flex-wrap gap-1">
+              <span className="font-medium">{label}：</span>
+              <span className="break-all">{value}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {onRetry && (
+        <button
+          type="button"
+          className={retryButtonClasses}
+          onClick={(event) => {
+            if (typeof onRetry === 'function') {
+              onRetry(event);
+            }
+          }}
+        >
+          {retryLabel}
+        </button>
+      )}
+    </div>
+  );
+}
+
+ApiErrorNotice.propTypes = {
+  error: PropTypes.oneOfType([
+    PropTypes.instanceOf(Error),
+    PropTypes.shape({ message: PropTypes.string })
+  ]),
+  onRetry: PropTypes.func,
+  retryLabel: PropTypes.string,
+  className: PropTypes.string,
+  compact: PropTypes.bool,
+  includeResponseBody: PropTypes.bool
+};
+
+export default ApiErrorNotice;
+

--- a/src/components/EventManagerPage.jsx
+++ b/src/components/EventManagerPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { getEventsByUserId } from '../api';
 import EventManager from './EventManager';
 import { useAsync } from '../utils/useAsync.js';
+import { ApiErrorNotice } from './ApiErrorNotice.jsx';
 import { isProductionReady as globalIsProductionReady } from '../env.js';
 import { useAuth } from '../contexts/AuthContext'; // 使用AuthContext而不是直接使用useAuthenticator
 
@@ -153,9 +154,8 @@ const EventManagerPage = () => {
             <span className="text-xl text-gray-600 font-medium">正在加载事件...</span>
           </div>
         ) : loadError ? (
-          <div className="p-6 text-center">
-            <p className="text-red-600 mb-4">加载事件失败：{loadError.message || '未知错误'}</p>
-            <button onClick={handleRetry} className="px-4 py-2 bg-purple-600 hover:bg-purple-500 text-white rounded-lg text-sm">重试</button>
+          <div className="p-6">
+            <ApiErrorNotice error={loadError} onRetry={handleRetry} />
           </div>
         ) : (
           <EventManager

--- a/src/components/MyPage.jsx
+++ b/src/components/MyPage.jsx
@@ -8,6 +8,7 @@ import { isProductionReady as globalIsProductionReady } from '../env.js';
 import { getUserDisplayName } from '../utils/avatar.js';
 import { useAuth } from '../contexts/AuthContext.jsx';
 import PendingSyncButton from './PendingSyncButton.jsx';
+import { ApiErrorNotice } from './ApiErrorNotice.jsx';
 
 /**
  * @en The MyPage component serves as the user's personal dashboard. It fetches,
@@ -167,30 +168,8 @@ const MyPage = () => {
 
       {/* 错误处理 */}
       {loadError && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-6 mb-8">
-          <div className="flex items-center">
-            <div className="flex-shrink-0">
-              <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
-              </svg>
-            </div>
-            <div className="ml-3">
-              <h3 className="text-sm font-medium text-red-800">
-                加载数据时发生错误
-              </h3>
-              <div className="mt-2 text-sm text-red-700">
-                <p>{loadError.message || '未知错误'}</p>
-              </div>
-              <div className="mt-4">
-                <button
-                  onClick={handleRetryFetch}
-                  className="bg-red-100 hover:bg-red-200 text-red-800 px-4 py-2 rounded-md text-sm font-medium"
-                >
-                  重试
-                </button>
-              </div>
-            </div>
-          </div>
+        <div className="mb-8">
+          <ApiErrorNotice error={loadError} onRetry={handleRetryFetch} />
         </div>
       )}
 

--- a/src/components/PostList.jsx
+++ b/src/components/PostList.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useAsync } from '../utils/useAsync.js';
+import { ApiError } from '../utils/apiError.js';
+import { ApiErrorNotice } from './ApiErrorNotice.jsx';
 
 const PostList = () => {
   const [posts, setPosts] = useState([]);
@@ -10,7 +12,9 @@ const PostList = () => {
   // 使用 useAsync 统一数据获取
   const postsAsync = useAsync(async () => {
     const res = await fetch('/posts.json');
-    if (!res.ok) throw new Error('无法加载 posts.json');
+    if (!res.ok) {
+      throw await ApiError.fromResponse(res, { requestMethod: 'GET', requestPath: '/posts.json' });
+    }
     return await res.json();
   }, []);
 
@@ -101,9 +105,8 @@ const PostList = () => {
       <div className="container mx-auto p-4">
         {/* 错误与加载状态 */}
         {postsAsync.error && (
-          <div className="mb-4 p-3 rounded-md bg-red-50 border border-red-200 text-red-600 text-sm flex items-center justify-between">
-            <span>加载文档列表失败：{postsAsync.error.message}</span>
-            <button onClick={postsAsync.execute} className="px-2 py-1 text-xs bg-red-600 text-white rounded">重试</button>
+          <div className="mb-4">
+            <ApiErrorNotice error={postsAsync.error} onRetry={postsAsync.execute} />
           </div>
         )}
         {postsAsync.loading && (

--- a/src/components/PostViewer.jsx
+++ b/src/components/PostViewer.jsx
@@ -3,6 +3,8 @@ import { useSearchParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useAsync } from '../utils/useAsync.js';
+import { ApiError, ClientError } from '../utils/apiError.js';
+import { ApiErrorNotice } from './ApiErrorNotice.jsx';
 
 const PostViewer = () => {
   const [searchParams] = useSearchParams();
@@ -22,16 +24,18 @@ const PostViewer = () => {
   const docAsync = useAsync(async () => {
     if (!docPath) return '';
     if (!isValidMarkdownFile(docPath)) {
-      throw new Error('无效的文档路径。只允许访问 .md 文件。');
+      throw new ClientError('无效的文档路径。只允许访问 .md 文件。', { requestPath: docPath });
     }
     const fullPath = `/posts/${docPath}`;
     const res = await fetch(fullPath);
-    if (!res.ok) throw new Error(`文档未找到: ${res.status}`);
+    if (!res.ok) {
+      throw await ApiError.fromResponse(res, { requestMethod: 'GET', requestPath: fullPath });
+    }
     return await res.text();
   }, [docPath], { preserveValue: false });
 
   const loading = docAsync.loading;
-  const error = docAsync.error?.message || '';
+  const error = docAsync.error;
   const content = docAsync.value || '';
 
   if (!docPath) {
@@ -62,10 +66,9 @@ const PostViewer = () => {
   if (error) {
     return (
       <div className="max-w-3xl mx-auto p-4">
-        <div className="rounded-2xl bg-red-50 ring-1 ring-red-200 text-red-800 shadow-sm p-6 md:p-8">
-          <h3 className="text-lg font-semibold mb-2">错误</h3>
-          <p className="text-sm text-red-700">{error}</p>
-          <button onClick={docAsync.execute} className="mt-4 px-3 py-1.5 text-xs bg-red-600 hover:bg-red-500 text-white rounded-md">重试</button>
+        <div className="rounded-2xl bg-white/70 backdrop-blur-sm ring-1 ring-gray-200 shadow-sm p-6 md:p-8 space-y-3">
+          <h3 className="text-lg font-semibold text-gray-900">无法加载文档</h3>
+          <ApiErrorNotice error={error} onRetry={docAsync.execute} />
         </div>
       </div>
     );

--- a/src/components/ProfileSetup.jsx
+++ b/src/components/ProfileSetup.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { ensureAppError } from '../utils/apiError.js';
+import { ApiErrorNotice } from './ApiErrorNotice.jsx';
 
 const ProfileSetup = ({ onComplete, onSkip }) => {
   const { completeProfileSetup, user } = useAuth();
@@ -10,7 +12,7 @@ const ProfileSetup = ({ onComplete, onSkip }) => {
     areSocialsPublic: false
   });
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
+  const [error, setError] = useState(null);
   const [currentSocial, setCurrentSocial] = useState({ platform: '', handle: '' });
 
   // 社交平台选项
@@ -46,14 +48,18 @@ const ProfileSetup = ({ onComplete, onSkip }) => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setLoading(true);
-    setError('');
+    setError(null);
 
     try {
       await completeProfileSetup({ profile: formData });
       onComplete?.();
     } catch (err) {
-      setError('资料设置失败，请重试');
       console.error('Profile setup error:', err);
+      setError(ensureAppError(err, {
+        message: '资料设置失败，请重试',
+        requestMethod: 'POST',
+        requestPath: '/user/profile-setup'
+      }));
     } finally {
       setLoading(false);
     }
@@ -74,8 +80,12 @@ const ProfileSetup = ({ onComplete, onSkip }) => {
         onSkip?.();
       })
       .catch((err) => {
-        setError('跳过设置失败，请重试');
         console.error('Skip setup error:', err);
+        setError(ensureAppError(err, {
+          message: '跳过设置失败，请重试',
+          requestMethod: 'POST',
+          requestPath: '/user/profile-setup'
+        }));
       })
       .finally(() => {
         setLoading(false);
@@ -98,8 +108,8 @@ const ProfileSetup = ({ onComplete, onSkip }) => {
         </div>
 
         {error && (
-          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
-            {error}
+          <div className="mb-6">
+            <ApiErrorNotice error={error} />
           </div>
         )}
 

--- a/src/components/ProfileSetupWizard.jsx
+++ b/src/components/ProfileSetupWizard.jsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { setupUserProfile } from '../api';
+import { ensureAppError } from '../utils/apiError.js';
+import { ApiErrorNotice } from './ApiErrorNotice.jsx';
 
 const ProfileSetupWizard = ({ onComplete, canSkip = false }) => {
   const { user, refreshUserProfile } = useAuth();
@@ -9,6 +11,7 @@ const ProfileSetupWizard = ({ onComplete, canSkip = false }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [apiError, setApiError] = useState(null);
 
   const [formData, setFormData] = useState({
     name: '',
@@ -43,6 +46,7 @@ const ProfileSetupWizard = ({ onComplete, canSkip = false }) => {
       [field]: value
     }));
     setError('');
+    setApiError(null);
   };
 
   const addSocialAccount = () => {
@@ -109,6 +113,7 @@ const ProfileSetupWizard = ({ onComplete, canSkip = false }) => {
     if (currentStep < totalSteps) {
       setCurrentStep(prev => prev + 1);
       setError('');
+      setApiError(null);
     }
   };
 
@@ -116,6 +121,7 @@ const ProfileSetupWizard = ({ onComplete, canSkip = false }) => {
     if (currentStep > 1) {
       setCurrentStep(prev => prev - 1);
       setError('');
+      setApiError(null);
     }
   };
 
@@ -161,7 +167,12 @@ const ProfileSetupWizard = ({ onComplete, canSkip = false }) => {
       finishSetup();
     } catch (error) {
       console.error('设置用户资料失败:', error);
-      setError(error.message || '设置失败，请重试');
+      setError('');
+      setApiError(ensureAppError(error, {
+        message: error.message || '设置失败，请重试',
+        requestMethod: 'POST',
+        requestPath: '/user/profile-setup'
+      }));
     } finally {
       setLoading(false);
     }
@@ -424,6 +435,11 @@ const ProfileSetupWizard = ({ onComplete, canSkip = false }) => {
             </div>
 
             {/* 错误消息 */}
+            {apiError && (
+              <div className="mb-6">
+                <ApiErrorNotice error={apiError} />
+              </div>
+            )}
             {error && (
               <div className="mb-6 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
                 {error}

--- a/src/components/PublicDashboard.jsx
+++ b/src/components/PublicDashboard.jsx
@@ -14,6 +14,7 @@ import { Bar, Line } from 'react-chartjs-2';
 import { getAllEvents, getUserPublicProfile } from '../api';
 import { useAsync } from '../utils/useAsync.js';
 import EnhancedDataCharts from './EnhancedDataCharts.jsx';
+import { ApiErrorNotice } from './ApiErrorNotice.jsx';
 
 /**
  * @en The PublicDashboard component displays aggregated and anonymized data from all users.
@@ -323,9 +324,8 @@ const PublicDashboard = () => {
   // Error state
   if (error) {
     return (
-      <div className="p-10 text-center">
-        <p className="text-red-500 mb-4">加载公开仪表板失败：{error.message || '未知错误'}</p>
-        <button onClick={eventsAsync.execute} className="px-4 py-2 rounded-lg bg-pink-600 text-white hover:bg-pink-500">重试</button>
+      <div className="p-10">
+        <ApiErrorNotice error={error} onRetry={eventsAsync.execute} />
       </div>
     );
   }

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -15,6 +15,7 @@ import { useAsync } from '../utils/useAsync.js';
 import { useAuth } from '../contexts/AuthContext.jsx';
 import { isProductionReady } from '../env.js';
 import DevModeTest from './DevModeTest.jsx';
+import { ApiErrorNotice } from './ApiErrorNotice.jsx';
 
 ChartJS.register(
   CategoryScale,
@@ -330,7 +331,9 @@ const Timeline = () => {
 
   const handleRetry = () => {
     eventsAsync.execute();
-    aiAsync.reset();
+    if (typeof aiAsync.execute === 'function') {
+      aiAsync.execute();
+    }
   };
 
   // 生成时间轴数据
@@ -357,15 +360,8 @@ const Timeline = () => {
 
       {/* 错误提示 */}
       {anyError && (
-        <div className="mb-8 p-4 rounded-xl border border-red-200 bg-red-50 text-red-700">
-          <p className="font-semibold mb-2">数据加载失败</p>
-          <p className="text-sm mb-3">{anyError?.message || '未知错误'}</p>
-          <button
-            onClick={handleRetry}
-            className="px-4 py-2 rounded-lg bg-red-600 text-white text-sm hover:bg-red-500"
-          >
-            重试
-          </button>
+        <div className="mb-8">
+          <ApiErrorNotice error={anyError} onRetry={handleRetry} />
         </div>
       )}
 

--- a/src/utils/apiError.js
+++ b/src/utils/apiError.js
@@ -1,0 +1,308 @@
+const FALLBACK_MESSAGE = '请求失败，请稍后重试';
+const GENERIC_MESSAGE = '发生未知错误';
+
+const headerNames = ['x-amzn-requestid', 'x-amz-request-id', 'x-request-id'];
+
+function readHeaderValue(headers, keys) {
+  if (!headers) return undefined;
+  try {
+    for (const key of keys) {
+      const value = typeof headers.get === 'function'
+        ? headers.get(key)
+        : headers[key] ?? headers[key?.toLowerCase?.()];
+      if (value) {
+        return value;
+      }
+    }
+  } catch (err) {
+    // ignore header access errors
+  }
+  return undefined;
+}
+
+function mergeDetails(current, incoming) {
+  if (incoming === undefined) return current;
+  if (current === undefined) return incoming;
+
+  if (Array.isArray(current) && Array.isArray(incoming)) {
+    return [...current, ...incoming];
+  }
+
+  if (typeof current === 'object' && current !== null && typeof incoming === 'object' && incoming !== null) {
+    return { ...current, ...incoming };
+  }
+
+  return incoming;
+}
+
+function mergeMeta(current, incoming) {
+  if (incoming === undefined) return current;
+  if (current === undefined) return incoming;
+  if (typeof current === 'object' && current !== null && typeof incoming === 'object' && incoming !== null) {
+    return { ...current, ...incoming };
+  }
+  return incoming;
+}
+
+function extractStatusCode(input, context) {
+  if (context?.statusCode !== undefined) return context.statusCode;
+  if (!input || typeof input !== 'object') return undefined;
+
+  return (
+    input.$metadata?.httpStatusCode ??
+    input.output?.statusCode ??
+    input.response?.status ??
+    input.statusCode ??
+    input.status ??
+    input.responseStatus
+  );
+}
+
+export class AppError extends Error {
+  constructor(message = GENERIC_MESSAGE, context = {}) {
+    super(message || GENERIC_MESSAGE);
+    this.name = 'AppError';
+    const {
+      statusCode,
+      requestMethod,
+      requestPath,
+      requestId,
+      responseBody,
+      details,
+      cause,
+      originalError,
+      errorCode,
+      meta
+    } = context;
+
+    if (statusCode !== undefined) this.statusCode = statusCode;
+    if (requestMethod !== undefined) this.requestMethod = requestMethod;
+    if (requestPath !== undefined) this.requestPath = requestPath;
+    if (requestId !== undefined) this.requestId = requestId;
+    if (responseBody !== undefined) this.responseBody = responseBody;
+    if (errorCode !== undefined) this.errorCode = errorCode;
+    if (details !== undefined) this.details = details;
+    if (meta !== undefined) this.meta = meta;
+    if (cause !== undefined && this.cause === undefined) this.cause = cause;
+    if (originalError !== undefined) this.originalError = originalError;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AppError);
+    }
+    if (!this.originalError && context.cause instanceof Error) {
+      this.originalError = context.cause;
+    }
+  }
+
+  applyContext(context = {}) {
+    if (!context) return this;
+    const {
+      message,
+      statusCode,
+      requestMethod,
+      requestPath,
+      requestId,
+      responseBody,
+      details,
+      cause,
+      originalError,
+      errorCode,
+      meta
+    } = context;
+
+    if (message) this.message = message;
+    if (statusCode !== undefined) this.statusCode = statusCode;
+    if (requestMethod !== undefined) this.requestMethod = requestMethod;
+    if (requestPath !== undefined) this.requestPath = requestPath;
+    if (requestId !== undefined) this.requestId = requestId;
+    if (responseBody !== undefined) this.responseBody = responseBody;
+    if (errorCode !== undefined) this.errorCode = errorCode;
+    if (details !== undefined) {
+      this.details = mergeDetails(this.details, details);
+    }
+    if (meta !== undefined) {
+      this.meta = mergeMeta(this.meta, meta);
+    }
+    if (cause !== undefined && this.cause === undefined) this.cause = cause;
+    if (originalError !== undefined && this.originalError === undefined) this.originalError = originalError;
+    return this;
+  }
+
+  static from(input, context = {}) {
+    if (input instanceof AppError) {
+      return input.applyContext(context);
+    }
+
+    let originalError = null;
+    if (input instanceof Error) {
+      originalError = input;
+    } else if (context.originalError instanceof Error) {
+      originalError = context.originalError;
+    } else if (input && typeof input === 'object' && input.message) {
+      originalError = new Error(String(input.message));
+    } else if (input !== undefined) {
+      originalError = new Error(typeof input === 'string' ? input : JSON.stringify(input));
+    }
+
+    const messageFromInput =
+      context.message ??
+      (input instanceof Error
+        ? input.message
+        : typeof input === 'string'
+          ? input
+          : input?.message);
+
+    const appError = new AppError(messageFromInput || GENERIC_MESSAGE, {
+      statusCode: extractStatusCode(input, context),
+      requestMethod: context.requestMethod ?? input?.request?.method ?? input?.method,
+      requestPath: context.requestPath ?? input?.request?.url ?? input?.url ?? context.url,
+      requestId: context.requestId,
+      responseBody: context.responseBody ?? input?.responseBody ?? input?.body ?? input?.data,
+      details: mergeDetails(context.details, input?.details),
+      errorCode: context.errorCode ?? input?.errorCode,
+      meta: mergeMeta(context.meta, input?.meta),
+      originalError: originalError ?? undefined
+    });
+
+    return appError;
+  }
+}
+
+export class ApiError extends AppError {
+  constructor(message = FALLBACK_MESSAGE, context = {}) {
+    super(message || FALLBACK_MESSAGE, context);
+    this.name = 'ApiError';
+  }
+
+  applyContext(context = {}) {
+    super.applyContext(context);
+    return this;
+  }
+
+  static from(input, context = {}) {
+    if (input instanceof ApiError) {
+      return input.applyContext(context);
+    }
+
+    const metadata = input?.$metadata ?? {};
+    const response = input?.response;
+    const headers = response?.headers || input?.headers;
+
+    const derivedStatus = extractStatusCode(input, context);
+    const derivedMethod = context.requestMethod ?? input?.request?.method ?? input?.config?.method ?? response?.method ?? context.method;
+    const derivedPath = context.requestPath ?? input?.request?.url ?? input?.config?.url ?? response?.url ?? input?.url ?? context.url;
+    const derivedRequestId = context.requestId ?? metadata.requestId ?? input?.requestId ?? readHeaderValue(headers, headerNames);
+
+    const message = context.message || input?.message || FALLBACK_MESSAGE;
+
+    const apiError = new ApiError(message, {
+      statusCode: derivedStatus,
+      requestMethod: derivedMethod,
+      requestPath: derivedPath,
+      requestId: derivedRequestId,
+      responseBody: context.responseBody ?? input?.responseBody ?? input?.body ?? input?.data,
+      details: mergeDetails(context.details, input?.details),
+      errorCode: context.errorCode ?? input?.errorCode,
+      originalError: input instanceof Error ? input : context.originalError
+    });
+
+    if (metadata.attempts) {
+      apiError.attempts = metadata.attempts;
+    }
+
+    return apiError;
+  }
+
+  static async fromResponse(response, context = {}) {
+    if (!response) {
+      return new ApiError(context.message || FALLBACK_MESSAGE, context);
+    }
+
+    let responseBody;
+    try {
+      if (response.clone) {
+        const cloned = response.clone();
+        const contentType = cloned.headers?.get?.('content-type');
+        if (contentType && contentType.includes('application/json')) {
+          responseBody = await cloned.json();
+        } else {
+          responseBody = await cloned.text();
+        }
+      }
+    } catch (err) {
+      responseBody = undefined;
+    }
+
+    return new ApiError(context.message || `请求失败，状态码 ${response.status}`, {
+      statusCode: response.status,
+      requestMethod: context.requestMethod ?? response.request?.method ?? context.method,
+      requestPath: context.requestPath ?? response.url ?? context.url,
+      requestId: context.requestId ?? readHeaderValue(response.headers, headerNames),
+      responseBody,
+      originalError: context.originalError instanceof Error ? context.originalError : undefined,
+      errorCode: context.errorCode,
+      details: context.details
+    });
+  }
+}
+
+export class AuthenticationError extends AppError {
+  constructor(message = '未登录：请求未发送，请先完成登录后重试。', context = {}) {
+    super(message, {
+      ...context,
+      statusCode: undefined,
+      errorCode: context.errorCode ?? 'AUTH_MISSING_ID_TOKEN',
+      details: mergeDetails(context.details, { 提示: '由于缺少身份凭证，请求未发送到服务器。' })
+    });
+    this.name = 'AuthenticationError';
+  }
+}
+
+export class ClientError extends AppError {
+  constructor(message = GENERIC_MESSAGE, context = {}) {
+    super(message, context);
+    this.name = 'ClientError';
+  }
+}
+
+export class ServiceError extends AppError {
+  constructor(message = GENERIC_MESSAGE, context = {}) {
+    super(message, context);
+    this.name = 'ServiceError';
+    if (context.serviceName !== undefined) this.serviceName = context.serviceName;
+  }
+
+  applyContext(context = {}) {
+    super.applyContext(context);
+    if (context?.serviceName !== undefined) {
+      this.serviceName = context.serviceName;
+    }
+    return this;
+  }
+}
+
+export function ensureAppError(error, context) {
+  return error instanceof AppError ? error.applyContext(context) : AppError.from(error, context);
+}
+
+export function ensureApiError(error, context) {
+  if (error instanceof ApiError) {
+    return error.applyContext(context);
+  }
+  if (error instanceof AppError) {
+    return error.applyContext(context);
+  }
+  return ApiError.from(error, context);
+}
+
+export function normalizeFetchError(response, context = {}) {
+  if (!response) {
+    return new ApiError(context.message || FALLBACK_MESSAGE, context);
+  }
+  return ApiError.from(response, {
+    ...context,
+    statusCode: response.status,
+    requestMethod: context.requestMethod ?? response.request?.method ?? context.method,
+    requestPath: context.requestPath ?? response.url ?? context.url
+  });
+}
+

--- a/src/utils/formatApiError.js
+++ b/src/utils/formatApiError.js
@@ -1,0 +1,120 @@
+import { ensureAppError, ApiError, AuthenticationError, ServiceError } from './apiError.js';
+
+const defaultLabels = {
+  summaryFallback: '请求过程中出现问题',
+  statusCode: '状态码',
+  requestMethod: '请求方法',
+  requestPath: '请求地址',
+  requestId: '请求 ID',
+  responseBody: '响应内容',
+  errorCode: '错误代码',
+  details: '详细信息',
+  notSent: '请求状态',
+  serviceName: '服务',
+  meta: '附加信息'
+};
+
+function toDisplayValue(value) {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch (err) {
+    return String(value);
+  }
+}
+
+function normalizeDetailItems(details, labels, fallbackLabel = labels.details) {
+  if (!details) return [];
+  if (Array.isArray(details)) {
+    return details
+      .map((item, index) => {
+        if (!item) return null;
+        if (typeof item === 'string') {
+          return { label: `${fallbackLabel}`, value: item };
+        }
+        if (typeof item === 'object') {
+          const label = item.label ?? `${fallbackLabel}`;
+          const value = item.value ?? toDisplayValue(item);
+          return value ? { label, value } : null;
+        }
+        return { label: `${fallbackLabel}[${index}]`, value: String(item) };
+      })
+      .filter(Boolean);
+  }
+
+  if (typeof details === 'object') {
+    return Object.entries(details)
+      .map(([key, value]) => ({ label: key, value: toDisplayValue(value) }))
+      .filter(item => item.value !== undefined);
+  }
+
+  const value = toDisplayValue(details);
+  return value ? [{ label: fallbackLabel, value }] : [];
+}
+
+export function formatApiError(error, options = {}) {
+  if (!error) return null;
+  const labels = { ...defaultLabels, ...(options.labels || {}) };
+  const appError = ensureAppError(error, options.context);
+
+  const summary = appError.message || labels.summaryFallback;
+  const detailItems = [];
+
+  if (appError.errorCode) {
+    detailItems.push({ label: labels.errorCode, value: appError.errorCode });
+  }
+
+  if (appError instanceof ApiError) {
+    if (appError.statusCode !== undefined && appError.statusCode !== null) {
+      detailItems.push({ label: labels.statusCode, value: appError.statusCode });
+    }
+  } else if (appError instanceof AuthenticationError) {
+    detailItems.push({ label: labels.notSent, value: '请求未发送（鉴权失败）' });
+  } else if (appError.statusCode !== undefined && appError.statusCode !== null) {
+    detailItems.push({ label: labels.statusCode, value: appError.statusCode });
+  }
+
+  if (appError instanceof ServiceError && appError.serviceName) {
+    detailItems.push({ label: labels.serviceName, value: appError.serviceName });
+  }
+
+  if (appError.requestMethod) {
+    const method = typeof appError.requestMethod === 'string'
+      ? appError.requestMethod.toUpperCase()
+      : appError.requestMethod;
+    detailItems.push({ label: labels.requestMethod, value: method });
+  }
+  if (appError.requestPath) {
+    detailItems.push({ label: labels.requestPath, value: appError.requestPath });
+  }
+  if (appError.requestId) {
+    detailItems.push({ label: labels.requestId, value: appError.requestId });
+  }
+  if (options.includeResponseBody && appError.responseBody) {
+    const responseValue = toDisplayValue(appError.responseBody);
+    if (responseValue) {
+      detailItems.push({ label: labels.responseBody, value: responseValue });
+    }
+  }
+
+  const detailFromError = normalizeDetailItems(appError.details, labels);
+  detailItems.push(...detailFromError);
+
+  const metaDetailItems = normalizeDetailItems(appError.meta, labels, labels.meta);
+  detailItems.push(...metaDetailItems);
+
+  const extraDetailItems = normalizeDetailItems(options.additionalDetails, labels);
+  detailItems.push(...extraDetailItems);
+
+  const detailText = detailItems.map(item => `${item.label}：${item.value}`).join(' · ');
+
+  return {
+    summary,
+    detailItems,
+    detailText,
+    error: appError
+  };
+}
+
+export default formatApiError;

--- a/src/utils/useAsync.js
+++ b/src/utils/useAsync.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { ensureAppError } from './apiError.js';
 
 /**
  * 通用异步请求 hook
@@ -30,8 +31,9 @@ export function useAsync(asyncFn, deps = [], options = {}) {
       }
       return result;
     } catch (err) {
+      const enrichedError = ensureAppError(err);
       if (abortRef.current === currentCallId) {
-        setError(err instanceof Error ? err : new Error(String(err)));
+        setError(enrichedError);
       }
       return undefined;
     } finally {


### PR DESCRIPTION
## Summary
- introduce a shared AppError hierarchy (ApiError, AuthenticationError, ServiceError, ClientError) with updated formatting utilities and notice rendering that expose REST metadata on demand
- update API wrappers and consumers to throw the appropriate error types, including ServiceError for logical failures and AuthenticationError for missing tokens, while normalizing upload failures
- swap UI error handling to the new ensureAppError helper so retryable screens surface accurate context without mislabelling client-side issues

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de97e3ade88324a4d5d2199b2d58a7